### PR TITLE
Update: add email barrier regex example

### DIFF
--- a/course/email-barrier/src.js
+++ b/course/email-barrier/src.js
@@ -1,0 +1,46 @@
+/**
+ * Temporary email barrier
+ *
+ * @desc There're many services provide us a
+ * temporary email, for example: Mailinator,
+ * Maildrop, Spamgourmet,... We have to block
+ * emails from those services to avoid spam
+ *
+ * -----------------------------------------------
+ * List of blocked services:
+ * -----------------------------------------------
+ * @mailinator.com - mailinator.com
+ * @maildrop.cc - maildrop.cc
+ * @dispostable.com - dispostable.com
+ * @getnada.com - getnada.com
+ * @spamgourmet.com - spamgourmet.com
+ * @sharklasers.com - sharklasers.com
+ * @guerrillamail.info - guerrillamail.info
+ * @guerrillamail.biz - guerrillamail.biz
+ * @guerrillamail.com - guerrillamail.com
+ * @guerrillamail.de - guerrillamail.de
+ * @guerrillamail.net - guerrillamail.net
+ * @guerrillamail.org - guerrillamail.org
+ * @guerrillamailblock.com - guerrillamailblock.com
+ * @grr.la - grr.la
+ * @pokemail.net - pokemail.net
+ * @spam4.me - spam4.me
+ * @harakirimail.com - harakirimail.com
+ * @yopmail.com - yopmail.com
+ * @yopmail.fr - yopmail.fr
+ * @yopmail.net - yopmail.net
+ * @mvrht.com - 10minutemail.com
+ * -----------------------------------------------
+ *
+ * @param {string} emailAddress
+ * @return {boolean} decide email address is
+ * valid or not
+ */
+function isTemporaryEmail(emailAddress) {
+  // Reuse email regex from angularjs
+  // @see https://github.com/angular/angular.js/blob/master/src/ng/directive/input.js#L14
+  // @see https://github.com/ownego/valdr
+  var regexPattern = /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@(?!mailinator|maildrop|dispostable|getnada|spamgourmet|sharklasers|guerrillamail|grr|pokemail|spam4|harakirimail|yopmail|mvrht)[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])+(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])+)*$/;
+
+  return !!emailAddress.match(regexPattern);
+}

--- a/course/email-barrier/test.js
+++ b/course/email-barrier/test.js
@@ -1,0 +1,115 @@
+describe('temporary email barrier:', function() {
+  it('should existed', function() {
+    expect(isTemporaryEmail).toBeDefined();
+  });
+
+  it('should accept valid email addresses', function() {
+    expect(isTemporaryEmail('baott@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('bao.tt@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('bao-tt@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('-baott@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('baott-@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('baott@own-ego.com')).toBe(true);
+    expect(isTemporaryEmail('baott@ownego.c-om')).toBe(true);
+    expect(isTemporaryEmail('bao_tt@ownego.com')).toBe(true);
+    expect(isTemporaryEmail('baott@ownego.gmail.com')).toBe(true);
+  });
+
+  it('should block null email address', function() {
+    expect(isTemporaryEmail('')).toBe(false);
+  });
+
+  it('should block invalid email addresses with white space', function() {
+    expect(isTemporaryEmail('bao tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao tt@own  ego.com')).toBe(false);
+    expect(isTemporaryEmail('bao tt@ownego.c om')).toBe(false);
+  });
+
+  it('should block invalid email addresses without @', function() {
+    expect(isTemporaryEmail('baott.ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which name begin or end with "."', function() {
+    expect(isTemporaryEmail('.baott@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('baott.@ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which domain name begin with "."', function() {
+    expect(isTemporaryEmail('baott@.ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which domain extension end with "."', function() {
+    expect(isTemporaryEmail('baott@ownego.com.')).toBe(false);
+  });
+
+  it('should block invalid email addresses which domain sections has less than 2 characters', function() {
+    expect(isTemporaryEmail('baott@o.wnego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego.c.om')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego..com')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego.com.a')).toBe(false);
+  });
+
+  it('should block invalid email addresses which domain sections begin or end with "-"', function() {
+    expect(isTemporaryEmail('baott@-ownego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego-.com')).toBe(false);
+    expect(isTemporaryEmail('baott@-ownego-.com')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego.-com')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego.com-')).toBe(false);
+    expect(isTemporaryEmail('baott@ownego.-com-')).toBe(false);
+  });
+
+  it('should block invalid email addresses which name section is longer than 64 characters', function() {
+    expect(isTemporaryEmail('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which has length longer than 255 characters', function() {
+    expect(isTemporaryEmail('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which name section contains one of these special charaters (@ (  ) [ ] < > , ; : " "backslash")', function() {
+    expect(isTemporaryEmail('bao@tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao(tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao)tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao[tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao]tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao<tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao>tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao,tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao;tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao:tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao"tt@ownego.com')).toBe(false);
+    expect(isTemporaryEmail('bao\tt@ownego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which domain sections contain any characters other than alphanumeric and "-"', function() {
+    expect(isTemporaryEmail('baott@own*ego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@own$ego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@own@ego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@own~ego.com')).toBe(false);
+    expect(isTemporaryEmail('baott@own_ego.com')).toBe(false);
+  });
+
+  it('should block invalid email addresses which come from temporary email services like Mailinator, Maildrop,...', function() {
+    expect(isTemporaryEmail('baott@mailinator.com')).toBe(false);
+    expect(isTemporaryEmail('baott@maildrop.cc')).toBe(false);
+    expect(isTemporaryEmail('baott@dispostable.com')).toBe(false);
+    expect(isTemporaryEmail('baott@getnada.com')).toBe(false);
+    expect(isTemporaryEmail('baott@spamgourmet.com')).toBe(false);
+    expect(isTemporaryEmail('baott@sharklasers.com')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.info')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.biz')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.com')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.de')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.net')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamail.org')).toBe(false);
+    expect(isTemporaryEmail('baott@guerrillamailblock.com')).toBe(false);
+    expect(isTemporaryEmail('baott@grr.la')).toBe(false);
+    expect(isTemporaryEmail('baott@pokemail.net')).toBe(false);
+    expect(isTemporaryEmail('baott@spam4.me')).toBe(false);
+    expect(isTemporaryEmail('baott@harakirimail.com')).toBe(false);
+    expect(isTemporaryEmail('baott@yopmail.com')).toBe(false);
+    expect(isTemporaryEmail('baott@yopmail.fr')).toBe(false);
+    expect(isTemporaryEmail('baott@yopmail.net')).toBe(false);
+    expect(isTemporaryEmail('baott@mvrht.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
This also contains different rules to validate email compared to 'email-address' example.